### PR TITLE
增加全局出入参日志

### DIFF
--- a/src/Sino.Web/Filter/InputOutputLogFilter.cs
+++ b/src/Sino.Web/Filter/InputOutputLogFilter.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using NLog;
+using Sino.Web.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Sino.Web.Filter
+{
+    /// <summary>
+    /// 输入/输出 日志记录
+    /// </summary>
+    public class InputOutputLogFilter : ActionFilterAttribute
+    {
+        public static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            _logger.Info(new LogInfo()
+            {
+                Method = context.ActionDescriptor.RouteValues["controller"],
+                Argument = new
+                {
+                    RequestId = context.HttpContext.TraceIdentifier,
+                    Arguments = context.ActionArguments,
+                    Host = GetClientUserIp(context)
+                },
+                Description = "入参记录"
+            });
+            base.OnActionExecuting(context);
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            OutputLogAttribute outputlogattribute = (OutputLogAttribute)((ControllerActionDescriptor)context.ActionDescriptor).MethodInfo.GetCustomAttribute(typeof(OutputLogAttribute), false);
+            //判断是否需要开启出参日志记录
+            if (outputlogattribute!=null)
+            {
+                _logger.Info(new LogInfo()
+                {
+                    Method = context.ActionDescriptor.RouteValues["controller"],
+                    Argument = new
+                    {
+                        RequestId = context.HttpContext.TraceIdentifier,
+                        context.Result,
+                        Host = GetClientUserIp(context)
+                    },
+                    Description = "出参记录"
+                });
+            }
+            base.OnActionExecuted(context);
+        }
+
+        /// <summary>
+        /// 获取客户Ip
+        /// </summary>
+        private string GetClientUserIp(ActionContext context)
+        {
+            var ip = context.HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (string.IsNullOrEmpty(ip))
+                ip = context.HttpContext.Connection.RemoteIpAddress.ToString();
+            return ip;
+        }
+    }
+}

--- a/src/Sino.Web/Filter/OutputLogAttribute.cs
+++ b/src/Sino.Web/Filter/OutputLogAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sino.Web.Filter
+{
+    public class OutputLogAttribute: Attribute
+    {
+    }
+}

--- a/src/Sino.Web/Sino.Web.csproj
+++ b/src/Sino.Web/Sino.Web.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.0-beta4</Version>
+    <Version>2.0.0-beta5</Version>
     <Authors>y-z-f</Authors>
     <Company>江苏斯诺物联科技有限公司</Company>
     <PackageIconUrl>http://avatars0.githubusercontent.com/u/16951448?v=3&amp;s=70</PackageIconUrl>
@@ -12,6 +12,7 @@
     <PackageLicenseUrl>https://github.com/Vip56/Sino.Web/blob/dev/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Vip56/Sino.Web</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Vip56/Sino.Web.git</RepositoryUrl>
+    <AssemblyVersion>2.0.0.5</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebApp/Controllers/ValuesController.cs
+++ b/test/WebApp/Controllers/ValuesController.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Microsoft.AspNetCore.Authorization;
 using System.Diagnostics;
 using WebApp.Services;
+using Sino.Web.Filter;
 
 namespace WebApp.Controllers
 {
@@ -31,6 +32,7 @@ namespace WebApp.Controllers
 
         // GET api/values
         [HttpGet]
+        [OutputLog]
         public async Task<IEnumerable<a>> Get()
         {
             Stopwatch watch = Stopwatch.StartNew();

--- a/test/WebApp/DefaultAuthenticationEvents.cs
+++ b/test/WebApp/DefaultAuthenticationEvents.cs
@@ -1,13 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
-using Sino.Web.ViewModels;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace WebApp
+﻿namespace WebApp
 {
     //public class DefaultAuthenticationEvents : CookieAuthenticationEvents
     //{

--- a/test/WebApp/DefaultInterceptorAttribute.cs
+++ b/test/WebApp/DefaultInterceptorAttribute.cs
@@ -1,25 +1,19 @@
-﻿using AspectCore.Lite.Abstractions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace WebApp
+﻿namespace WebApp
 {
-    public class DefaultInterceptorAttribute : InterceptorAttribute
-    {
-        public override async Task Invoke(IAspectContext context, AspectDelegate next)
-        {
-            try
-            {
-                Console.WriteLine("Before service call");
-                await next(context);
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("Service throw an exception");
-                throw;
-            }
-        }
-    }
+    //public class DefaultInterceptorAttribute : InterceptorAttribute
+    //{
+    //    public override async Task Invoke(IAspectContext context, AspectDelegate next)
+    //    {
+    //        try
+    //        {
+    //            Console.WriteLine("Before service call");
+    //            await next(context);
+    //        }
+    //        catch (Exception)
+    //        {
+    //            Console.WriteLine("Service throw an exception");
+    //            throw;
+    //        }
+    //    }
+    //}
 }

--- a/test/WebApp/Startup.cs
+++ b/test/WebApp/Startup.cs
@@ -41,7 +41,8 @@ namespace WebApp
             services.AddMvc(x =>
             {
                 x.Filters.Add(typeof(GlobalResultFilter));
-                x.Filters.Add(typeof(CheckSignatureFilter));
+                //x.Filters.Add(typeof(CheckSignatureFilter));
+                x.Filters.Add(typeof(InputOutputLogFilter));
             });
             services.Configure<GzipCompressionProviderOptions>(options => options.Level = System.IO.Compression.CompressionLevel.Fastest);
             services.AddResponseCompression(options =>
@@ -72,7 +73,7 @@ namespace WebApp
             loggerFactory.AddDebug();
             loggerFactory.AddNLog();
 
-            NLog.LogManager.LoadConfiguration("nlog.config");
+            loggerFactory.ConfigureNLog($"nlog.{env.EnvironmentName}.config");
 
             app.UseResponseCompression();
             //app.UseCookieAuthentication(new CookieAuthenticationOptions()

--- a/test/WebApp/WebApp.csproj
+++ b/test/WebApp/WebApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
@@ -31,6 +32,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sino.Web\Sino.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/test/WebApp/nlog.Development.config
+++ b/test/WebApp/nlog.Development.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true"
+      internalLogLevel="Debug"
+      internalLogToTrace="true">
+  <targets>
+    <target name="lognet"
+            xsi:type="Network"
+            address="udp://127.0.0.1:4561" >
+      <layout xsi:type="JsonLayout">
+        <attribute name="type" layout="local-cds-master" />
+        <attribute name="date" layout="${longdate}" />
+        <attribute name="level" layout="${level:uppercase=true}" />
+        <attribute name="callSite" layout="${callsite:className=true:methodName=true:skipFrames=1}" />
+        <attribute name="message" layout="${message}" />
+        <attribute name="exception" layout="${exception:format=toString,Data}" />
+        <attribute name="fileName" layout="${callsite:fileName=true:includeSourcePath=true}" />
+      </layout>
+    </target>
+    <target name="console"
+            xsi:type="ColoredConsole"
+            layout="${longdate} [${level:uppercase=true}] ${callsite:className=true:methodName=true:skipFrames=1} ${message} ${exception:format=toString,Data} @${callsite:fileName=true:includeSourcePath=true}"/>
+
+    <target xsi:type="Null" name="blackhole" />
+  </targets>
+  <rules>
+    <logger name="Microsoft.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="System.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="*" minlevel="Debug" writeTo="lognet,console" />
+  </rules>
+</nlog>

--- a/test/WebApp/nlog.Production.config
+++ b/test/WebApp/nlog.Production.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true"
+      internalLogLevel="Debug"
+      internalLogToTrace="true">
+  <targets>
+    <target name="lognet"
+            xsi:type="Network"
+            address="udp://10.247.107.52:4561" >
+      <layout xsi:type="JsonLayout">
+        <attribute name="type" layout="newcdsenterprisemaster" />
+        <attribute name="date" layout="${longdate}" />
+        <attribute name="level" layout="${level:uppercase=true}" />
+        <attribute name="callSite" layout="${callsite:className=true:methodName=true:skipFrames=1}" />
+        <attribute name="message" layout="${message}" />
+        <attribute name="exception" layout="${exception:format=toString,Data}" />
+        <attribute name="fileName" layout="${callsite:fileName=true:includeSourcePath=true}" />
+      </layout>
+    </target>
+    <target name="console"
+            xsi:type="ColoredConsole"
+            layout="${longdate} [${level:uppercase=true}] ${callsite:className=true:methodName=true:skipFrames=1} ${message} ${exception:format=toString,Data} @${callsite:fileName=true:includeSourcePath=true}"/>
+
+    <target xsi:type="Null" name="blackhole" />
+  </targets>
+  <rules>
+    <logger name="Microsoft.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="System.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="*" minlevel="Debug" writeTo="lognet" />
+  </rules>
+</nlog>

--- a/test/WebApp/nlog.Staging.config
+++ b/test/WebApp/nlog.Staging.config
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true"
+      internalLogLevel="Debug"
+      internalLogToTrace="true">
+  <targets>
+    <target name="lognet"
+            xsi:type="Network"
+            address="udp://10.247.107.52:4561" >
+      <layout xsi:type="JsonLayout">
+        <attribute name="type" layout="newcdsenterprisedev" />
+        <attribute name="date" layout="${longdate}" />
+        <attribute name="level" layout="${level:uppercase=true}" />
+        <attribute name="callSite" layout="${callsite:className=true:methodName=true:skipFrames=1}" />
+        <attribute name="message" layout="${message}" />
+        <attribute name="exception" layout="${exception:format=toString,Data}" />
+        <attribute name="fileName" layout="${callsite:fileName=true:includeSourcePath=true}" />
+      </layout>
+    </target>
+    <target name="console"
+            xsi:type="ColoredConsole"
+            layout="${longdate} [${level:uppercase=true}] ${callsite:className=true:methodName=true:skipFrames=1} ${message} ${exception:format=toString,Data} @${callsite:fileName=true:includeSourcePath=true}"/>
+
+    <target xsi:type="Null" name="blackhole" />
+  </targets>
+  <rules>
+    <logger name="Microsoft.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="System.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="*" minlevel="Debug" writeTo="lognet" />
+    <logger name="*" minlevel="Debug" writeTo="console" />
+  </rules>
+</nlog>

--- a/test/WebApp/nlog.config
+++ b/test/WebApp/nlog.config
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      throwConfigExceptions="true"
+      internalLogLevel="Debug"
+      internalLogToTrace="true">
+  <targets>
+    <target name="lognet"
+            xsi:type="Network"
+             address="udp://127.0.0.1:4561" >
+      <layout xsi:type="JsonLayout">
+        <attribute name="type" layout="localnewcdsenterprise" />
+        <attribute name="date" layout="${longdate}" />
+        <attribute name="level" layout="${level:uppercase=true}" />
+        <attribute name="callSite" layout="${callsite:className=true:methodName=true:skipFrames=1}" />
+        <attribute name="message" layout="${message}" />
+        <attribute name="exception" layout="${exception:format=toString,Data}" />
+        <attribute name="fileName" layout="${callsite:fileName=true:includeSourcePath=true}" />
+      </layout>
+    </target>
+    <target name="console"
+            xsi:type="ColoredConsole"
+            layout="${longdate} [${level:uppercase=true}] ${callsite:className=true:methodName=true:skipFrames=1} ${message} ${exception:format=toString,Data} @${callsite:fileName=true:includeSourcePath=true}"/>
+    <target xsi:type="Null" name="blackhole" />
+  </targets>
+  <rules>
+    <logger name="Microsoft.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="System.*" minLevel="Trace" writeTo="blackhole" final="true" />
+    <logger name="*" minlevel="Debug" writeTo="lognet" />
+  </rules>
+</nlog>


### PR DESCRIPTION
使用方法 Startup ConfigureServices中注入
services.AddMvc(x =>
{
    x.Filters.Add(typeof(InputOutputLogFilter));
});
默认不开启出参日志 如需使用请使用特性
[OutputLog]
开启出参日志